### PR TITLE
Allow rendering via `TEXTURE-<texture id>`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "ISC",
             "dependencies": {
                 "axios": "^0.21.1",
-                "canvas": "^2.8.0",
+                "canvas": "^2.11.2",
                 "colors": "^1.4.0",
                 "dotenv": "^10.0.0",
                 "express": "^4.17.1",
@@ -1300,13 +1300,13 @@
             }
         },
         "node_modules/canvas": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
-            "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+            "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
             "hasInstallScript": true,
             "dependencies": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
-                "nan": "^2.14.0",
+                "nan": "^2.17.0",
                 "simple-get": "^3.0.3"
             },
             "engines": {
@@ -5444,9 +5444,9 @@
             "dev": true
         },
         "node_modules/nan": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+            "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -7942,12 +7942,12 @@
             "dev": true
         },
         "canvas": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.8.0.tgz",
-            "integrity": "sha512-gLTi17X8WY9Cf5GZ2Yns8T5lfBOcGgFehDFb+JQwDqdOoBOcECS9ZWMEAqMSVcMYwXD659J8NyzjRY/2aE+C2Q==",
+            "version": "2.11.2",
+            "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.11.2.tgz",
+            "integrity": "sha512-ItanGBMrmRV7Py2Z+Xhs7cT+FNt5K0vPL4p9EZ/UX/Mu7hFbkxSjKF2KVtPwX7UYWp7dRKnrTvReflgrItJbdw==",
             "requires": {
                 "@mapbox/node-pre-gyp": "^1.0.0",
-                "nan": "^2.14.0",
+                "nan": "^2.17.0",
                 "simple-get": "^3.0.3"
             }
         },
@@ -11084,9 +11084,9 @@
             "dev": true
         },
         "nan": {
-            "version": "2.15.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-            "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+            "version": "2.18.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+            "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w=="
         },
         "natural-compare": {
             "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "homepage": "https://github.com/iAverages/SkinsAPI#readme",
     "dependencies": {
         "axios": "^0.21.1",
-        "canvas": "^2.8.0",
+        "canvas": "^2.11.2",
         "colors": "^1.4.0",
         "dotenv": "^10.0.0",
         "express": "^4.17.1",

--- a/src/helpers/profile.js
+++ b/src/helpers/profile.js
@@ -106,6 +106,7 @@ async function checkForUpdate(profile) {
 }
 
 async function getUUID(name) {
+    if (name.startsWith('TEXTURE-')) return name
     if (isUUID(name)) return name;
 
     const user = await ProfileDB.findOne({ name });
@@ -146,7 +147,8 @@ function useSecondLayer(skin) {
 }
 
 async function getSkin64(uuid) {
-    if (!isUUID(uuid)) throw new ApiError(400, "Invalid UUID");
+    if (uuid.startsWith('TEXTURE-')) return getBase64FromURL(`http://textures.minecraft.net/texture/${uuid.replace('TEXTURE-', '')}`)
+    else if (!isUUID(uuid)) throw new ApiError(400, "Invalid UUID");
     const profile = await getProfile(uuid);
     return profile.assets.skin.base64;
 }


### PR DESCRIPTION
Adds the ability to specify `TEXTURE-<texture id>` instead of the uuid/name and render by texture ID.